### PR TITLE
Correctly handle multiple engine listings.

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ function checkVersions(json, callback) {
     range = versions[type];
     cmd = childProcess.spawn(type, ['-v']);
 
-    cmd.stdout.on('data', function(data) {
+    cmd.stdout.on('data', function(type, range, data) {
       var version = data.toString().trim();
 
       if (!semver.satisfies(version, versions[type])) {
@@ -49,7 +49,7 @@ function checkVersions(json, callback) {
       }
 
       done();
-    });
+    }.bind(null, type, range));
   }
 };
 


### PR DESCRIPTION
The `type` and `range` variables end up only using the last specified `engine`. So, for instance, if `engines` is specified as follows:

```
  "engines": {
    "node": "=0.12.7",
    "npm": "=2.14.5"
  }
```

I get an error message:

```
[Error: [ERROR] npm version (v0.12.7) does not satisfy specified range (=2.14.5)
```

Binding the variables is one way to fix it, if a bit inelegant.
